### PR TITLE
Add minimal frontend scaffold

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+VITE_N8N_BASE_URL=http://localhost:5678
+VITE_N8N_GENERATE_PATH=/webhook/signage-generate
+VITE_N8N_STATUS_PATH=/webhook/signage-status
+VITE_N8N_BUILD_PATH=/webhook/signage-build

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,0 +1,4 @@
+:80 {
+  root * /srv
+  file_server
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+# build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY . .
+RUN npm ci && npm run build
+
+# run stage
+FROM caddy:2-alpine
+COPY --from=build /app/dist /srv
+COPY Caddyfile /etc/caddy/Caddyfile
+EXPOSE 80
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,44 @@
+# Dosa UI
+
+Minimal control panel for digital signage PoC. Talks directly to a local n8n instance via webhooks.
+
+## Development
+
+```bash
+npm i
+npm run dev
+```
+
+## Docker
+
+```bash
+docker build -t dosa-ui .
+```
+
+### docker-compose example
+
+```yaml
+version: '3'
+services:
+  n8n:
+    image: n8nio/n8n
+    ports:
+      - '5678:5678'
+  dosa-ui:
+    build: .
+    ports:
+      - '8080:80'
+```
+
+The UI expects the following webhook endpoints on n8n:
+
+- `${VITE_N8N_GENERATE_PATH}` (default `/webhook/signage-generate`)
+- `${VITE_N8N_STATUS_PATH}` (default `/webhook/signage-status`)
+- `${VITE_N8N_BUILD_PATH}` (default `/webhook/signage-build`)
+
+## TODO
+
+- Wire real n8n endpoints
+- Connect preview images from n8n
+- Replace dummy mp4 with real
+- Add error overlay

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dosa UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "dosa-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@types/node": "^20.5.9",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.8",
+    "@vitejs/plugin-react": "^4.0.3",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.30",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/public/player.html
+++ b/frontend/public/player.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dosa Player</title>
+</head>
+<body class="m-0 p-0">
+  <div id="root"></div>
+  <script type="module">
+    const params = new URLSearchParams(location.search);
+    const url = params.get('url');
+    if (url) {
+      const video = document.createElement('video');
+      video.src = url;
+      video.autoplay = true;
+      video.loop = true;
+      video.muted = true;
+      video.style.width = '100vw';
+      video.style.height = '100vh';
+      document.body.appendChild(video);
+    } else {
+      document.body.textContent = 'Brak URL';
+    }
+  </script>
+</body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,54 @@
+import { useStore } from './state/useStore';
+import SlideConfigList from './components/SlideConfigList';
+import GenerateButton from './components/GenerateButton';
+import JobProgress from './components/JobProgress';
+import SlidePreviewGrid from './components/SlidePreviewGrid';
+import DeployButton from './components/DeployButton';
+import PlayerWindow from './player/PlayerWindow';
+
+function App() {
+  const { jobStatus, finalVideoUrl } = useStore();
+
+  if (jobStatus === 'pending') {
+    return (
+      <div className="p-4 max-w-md mx-auto">
+        <h1 className="text-xl mb-4">Konfiguracja slajdów</h1>
+        <SlideConfigList />
+        <GenerateButton />
+      </div>
+    );
+  }
+
+  if (jobStatus === 'rendering') {
+    return (
+      <div className="p-4 text-center">
+        <JobProgress target="ready" />
+      </div>
+    );
+  }
+
+  if (jobStatus === 'ready') {
+    return (
+      <div className="p-4">
+        <SlidePreviewGrid />
+        <DeployButton />
+      </div>
+    );
+  }
+
+  if (jobStatus === 'building') {
+    return (
+      <div className="p-4 text-center">
+        <JobProgress target="complete" />
+      </div>
+    );
+  }
+
+  if (jobStatus === 'complete' && finalVideoUrl) {
+    return <PlayerWindow mp4Url={finalVideoUrl} />;
+  }
+
+  return <p>Błąd lub nieznany status</p>;
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,36 @@
+import type { GenerateRequest, JobStatusResponse, GeneratedSlide } from './types';
+
+const BASE = import.meta.env.VITE_N8N_BASE_URL ?? 'http://localhost:5678';
+const GENERATE_PATH = import.meta.env.VITE_N8N_GENERATE_PATH ?? '/webhook/signage-generate';
+const STATUS_PATH = import.meta.env.VITE_N8N_STATUS_PATH ?? '/webhook/signage-status';
+const BUILD_PATH = import.meta.env.VITE_N8N_BUILD_PATH ?? '/webhook/signage-build';
+
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json() as Promise<T>;
+}
+
+export function generateSlides(payload: GenerateRequest): Promise<JobStatusResponse> {
+  return request<JobStatusResponse>(GENERATE_PATH, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export function getJobStatus(jobId: string): Promise<JobStatusResponse> {
+  const url = `${STATUS_PATH}?id=${encodeURIComponent(jobId)}`;
+  return request<JobStatusResponse>(url);
+}
+
+export function buildJob(jobId: string, slides: GeneratedSlide[]): Promise<JobStatusResponse> {
+  return request<JobStatusResponse>(BUILD_PATH, {
+    method: 'POST',
+    body: JSON.stringify({ job_id: jobId, slides }),
+  });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,0 +1,44 @@
+export type SlideType =
+  | 'day'
+  | 'nameday'
+  | 'disrupt'
+  | 'news'
+  | 'fact'
+  | 'ad1'
+  | 'ad2';
+
+export interface SlideConfig {
+  type: SlideType;
+  enabled: boolean;
+  duration: number; // seconds
+  count?: number; // optional (news articles to include)
+}
+
+export interface GenerateRequest {
+  date: string; // ISO yyyy-mm-dd
+  resolution: string; // '1080x1920'
+  slides: SlideConfig[];
+  lang: string; // 'pl'
+}
+
+export interface GeneratedSlide {
+  type: SlideType;
+  png_url: string;
+  duration: number;
+}
+
+export type JobStatusValue =
+  | 'pending'
+  | 'rendering'
+  | 'ready'
+  | 'building'
+  | 'complete'
+  | 'error';
+
+export interface JobStatusResponse {
+  job_id: string;
+  status: JobStatusValue;
+  slides?: GeneratedSlide[];
+  mp4_url?: string;
+  message?: string;
+}

--- a/frontend/src/components/DeployButton.tsx
+++ b/frontend/src/components/DeployButton.tsx
@@ -1,0 +1,29 @@
+import { buildJob } from '../api/client';
+import { useStore } from '../state/useStore';
+
+export default function DeployButton() {
+  const { jobId, configSlides, generatedSlides, setJob } = useStore();
+
+  const handleDeploy = async () => {
+    if (!jobId) return;
+    const slides = configSlides
+      .filter((s) => s.enabled)
+      .map((s, i) => generatedSlides[i]);
+    try {
+      const res = await buildJob(jobId, slides);
+      setJob(res.job_id, res.status);
+    } catch (err) {
+      console.error(err);
+      alert('Błąd deploy');
+    }
+  };
+
+  return (
+    <button
+      className="mt-4 w-full bg-blue-600 text-white py-2"
+      onClick={handleDeploy}
+    >
+      DEPLOY
+    </button>
+  );
+}

--- a/frontend/src/components/GenerateButton.tsx
+++ b/frontend/src/components/GenerateButton.tsx
@@ -1,0 +1,32 @@
+import { generateSlides } from '../api/client';
+import { useStore } from '../state/useStore';
+import dayjs from 'dayjs';
+
+export default function GenerateButton() {
+  const { configSlides, setJob } = useStore();
+
+  const handleClick = async () => {
+    try {
+      const payload = {
+        date: dayjs().format('YYYY-MM-DD'),
+        resolution: '1080x1920',
+        slides: configSlides,
+        lang: 'pl',
+      } as const;
+      const res = await generateSlides(payload);
+      setJob(res.job_id, res.status);
+    } catch (err) {
+      console.error(err);
+      alert('Błąd generowania');
+    }
+  };
+
+  return (
+    <button
+      className="mt-4 w-full bg-blue-600 text-white py-2"
+      onClick={handleClick}
+    >
+      GENERUJ NA DZIŚ
+    </button>
+  );
+}

--- a/frontend/src/components/JobProgress.tsx
+++ b/frontend/src/components/JobProgress.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { getJobStatus } from '../api/client';
+import { useStore } from '../state/useStore';
+
+interface Props {
+  target: 'ready' | 'complete';
+}
+
+export default function JobProgress({ target }: Props) {
+  const { jobId, setJob, setGeneratedSlides, setFinalVideoUrl } = useStore();
+
+  useEffect(() => {
+    if (!jobId) return;
+    const interval = setInterval(async () => {
+      try {
+        const res = await getJobStatus(jobId);
+        setJob(jobId, res.status);
+        if (res.slides) setGeneratedSlides(res.slides);
+        if (res.mp4_url) setFinalVideoUrl(res.mp4_url);
+        if (res.status === target) clearInterval(interval);
+      } catch (err) {
+        console.error(err);
+      }
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [jobId, target, setJob, setGeneratedSlides, setFinalVideoUrl]);
+
+  return <p>Przetwarzanie... ({target})</p>;
+}

--- a/frontend/src/components/SlideConfigList.tsx
+++ b/frontend/src/components/SlideConfigList.tsx
@@ -1,0 +1,13 @@
+import { useStore } from '../state/useStore';
+import SlideRow from './SlideRow';
+
+export default function SlideConfigList() {
+  const slides = useStore((s) => s.configSlides);
+  return (
+    <div className="space-y-2">
+      {slides.map((slide, i) => (
+        <SlideRow key={slide.type} slide={slide} index={i} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/SlidePreviewGrid.tsx
+++ b/frontend/src/components/SlidePreviewGrid.tsx
@@ -1,0 +1,43 @@
+import { useStore } from '../state/useStore';
+
+export default function SlidePreviewGrid() {
+  const { generatedSlides, toggleSlide, reorderSlides, configSlides } = useStore();
+
+  const onDrag = (from: number, to: number) => {
+    reorderSlides(from, to);
+  };
+
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {configSlides.map((slide, idx) => (
+        <div
+          key={slide.type}
+          draggable
+          onDragStart={(e) => {
+            e.dataTransfer.setData('text/plain', String(idx));
+          }}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            const from = Number(e.dataTransfer.getData('text/plain'));
+            onDrag(from, idx);
+          }}
+          className={`border p-2 ${slide.enabled ? '' : 'opacity-50'}`}
+        >
+          <img
+            src={generatedSlides[idx]?.png_url}
+            alt={slide.type}
+            className="mb-2 w-full"
+          />
+          <div className="flex items-center justify-between">
+            <span className="capitalize">{slide.type}</span>
+            <input
+              type="checkbox"
+              checked={slide.enabled}
+              onChange={() => toggleSlide(slide.type)}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/SlideRow.tsx
+++ b/frontend/src/components/SlideRow.tsx
@@ -1,0 +1,35 @@
+import type { SlideConfig } from '../api/types';
+import { useStore } from '../state/useStore';
+
+interface Props {
+  slide: SlideConfig;
+  index: number;
+}
+
+export default function SlideRow({ slide, index }: Props) {
+  const { toggleSlide, setConfigSlides } = useStore();
+
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <input
+        type="checkbox"
+        checked={slide.enabled}
+        onChange={() => toggleSlide(slide.type)}
+      />
+      <span className="flex-1 capitalize">{slide.type}</span>
+      <input
+        type="number"
+        className="w-16 border px-1"
+        value={slide.duration}
+        min={1}
+        onChange={(e) =>
+          setConfigSlides(
+            useStore.getState().configSlides.map((s, i) =>
+              i === index ? { ...s, duration: Number(e.target.value) } : s
+            )
+          )
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/player/PlayerWindow.tsx
+++ b/frontend/src/player/PlayerWindow.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  mp4Url: string;
+}
+
+export default function PlayerWindow({ mp4Url }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  const enterFs = () => {
+    const el = videoRef.current;
+    if (el && el.requestFullscreen) el.requestFullscreen();
+  };
+
+  useEffect(() => {
+    videoRef.current?.play();
+  }, [mp4Url]);
+
+  return (
+    <div className="h-screen w-screen flex flex-col items-center justify-center bg-black">
+      <video ref={videoRef} src={mp4Url} loop muted className="w-full h-full" />
+      <button onClick={enterFs} className="mt-2 bg-blue-600 text-white px-4 py-1">
+        Pełny ekran
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/state/useStore.ts
+++ b/frontend/src/state/useStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+import type { SlideConfig, GeneratedSlide, JobStatusValue } from '../api/types';
+
+type Store = {
+  configSlides: SlideConfig[];
+  jobId: string | null;
+  jobStatus: JobStatusValue;
+  generatedSlides: GeneratedSlide[];
+  finalVideoUrl: string | null;
+  setConfigSlides: (slides: SlideConfig[]) => void;
+  setJob: (id: string | null, status: JobStatusValue) => void;
+  setGeneratedSlides: (slides: GeneratedSlide[]) => void;
+  toggleSlide: (type: SlideConfig['type']) => void;
+  reorderSlides: (from: number, to: number) => void;
+  setFinalVideoUrl: (url: string | null) => void;
+};
+
+const defaults: SlideConfig[] = [
+  { type: 'day', enabled: true, duration: 6 },
+  { type: 'nameday', enabled: true, duration: 6 },
+  { type: 'disrupt', enabled: false, duration: 8 },
+  { type: 'news', enabled: true, duration: 6, count: 1 },
+  { type: 'fact', enabled: true, duration: 6 },
+  { type: 'ad1', enabled: true, duration: 6 },
+  { type: 'ad2', enabled: false, duration: 6 },
+];
+
+export const useStore = create<Store>((set) => ({
+  configSlides: defaults,
+  jobId: null,
+  jobStatus: 'pending',
+  generatedSlides: [],
+  finalVideoUrl: null,
+  setConfigSlides: (slides) => set({ configSlides: slides }),
+  setJob: (id, status) => set({ jobId: id, jobStatus: status }),
+  setGeneratedSlides: (slides) => set({ generatedSlides: slides }),
+  toggleSlide: (type) =>
+    set((state) => ({
+      configSlides: state.configSlides.map((s) =>
+        s.type === type ? { ...s, enabled: !s.enabled } : s
+      ),
+    })),
+  reorderSlides: (from, to) =>
+    set((state) => {
+      const arr = [...state.configSlides];
+      const [moved] = arr.splice(from, 1);
+      arr.splice(to, 0, moved);
+      return { configSlides: arr };
+    }),
+  setFinalVideoUrl: (url) => set({ finalVideoUrl: url }),
+}));

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold Vite+React+TS app in `frontend`
- define slide, job, and API types
- create API client for n8n webhooks
- add Zustand store and simple UI components
- include Dockerfile with Caddy static serving
- document local usage and endpoints

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68790877317083248b7bbdcc609f9872